### PR TITLE
Update Readme to install gem from github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Other versions are untested but might work fine.
 
 Add this line to your application's Gemfile into `development` group:
 
-    gem 'snp-best-practices', git: 'git@git.snpdev.ru:saltpepper/snp-best-practices.git'
+    gem 'snp-best-practices', git: 'git@github.com:groony/snp-best-practices.git'
 
 And then execute:
 


### PR DESCRIPTION
Access to the private server this git repos is hosted on is restricted.

This changes the README to advise installing to the publicly accessible github repo.

Fixes #1 